### PR TITLE
FIX: "BEFORE" must come before the "SYSTEM"

### DIFF
--- a/cmake/dynamic_reconfigure-macros.cmake
+++ b/cmake/dynamic_reconfigure-macros.cmake
@@ -113,7 +113,7 @@ macro(dynreconf_called)
 
     # make sure we can find generated messages and that they overlay all other includes
     # Use system to skip warnings from these includes
-    include_directories(SYSTEM BEFORE ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+    include_directories(BEFORE SYSTEM ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
     # pass the include directory to catkin_package()
     list(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
     # ensure that the folder exists


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/command/include_directories.html
[AFTER|BEFORE] must come before the "SYSTEM".
There is a bug
-isystem .../BEFORE
cc1plus: error: .../BEFORE: No such file or directory [-Werror=missing-include-dirs]